### PR TITLE
Fixing errors with Python SFP

### DIFF
--- a/nidmm_sfp.py
+++ b/nidmm_sfp.py
@@ -20,8 +20,8 @@ def format_meas(reading, function, range, resolution):
         nidmm.Function.AC_CURRENT: "A AC",
         nidmm.Function.DC_CURRENT: "A DC",
         nidmm.Function.DIODE: "V Diode",
-        nidmm.Function._2_WIRE_RES: "Ohm",
-        nidmm.Function._4_WIRE_RES: "Ohm",
+        nidmm.Function.TWO_WIRE_RES: "Ohm",
+        nidmm.Function.FOUR_WIRE_RES: "Ohm",
         nidmm.Function.PERIOD: "s",
         nidmm.Function.FREQ: "Hz",
         nidmm.Function.AC_VOLTS_DC_COUPLED: "V AC",
@@ -281,6 +281,7 @@ class SFP(wx.Frame):
 
             self._session.configure_measurement_digits(nidmm.Function[current_function], current_range, current_digits)
             self._session._initiate()
+            self._status.SetLabel("Good!")
         except nidmm.Error as e:
             self._status.SetLabel(str(e))
 

--- a/niscope_sfp.py
+++ b/niscope_sfp.py
@@ -326,7 +326,7 @@ class SFP(wx.Frame):
 
         self._waveform_axes.clear()
         for wfm_info in wfm_infos:
-            self._waveform_axes.plot(self._cached_x_axis_values, wfm_info.wfm)
+            self._waveform_axes.plot(self._cached_x_axis_values, wfm_info.samples)
         self._waveform_canvas.draw()
 
     def OnConfigUpdate(self, event):  # noqa: N802


### PR DESCRIPTION
- Updated enums for NI-DMM based on the latest version.
- Updated to set _status to "Good!" to prevent persistent error.
- Updated NI-SCOPE to use "samples" due to change in waveform info.